### PR TITLE
Fix Deprecation Warning for Server Discovery and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const config = {
     // these are the default middleware options, see https://mongoosejs.com/docs/connections.html#options
     useNewUrlParser: true,
     useCreateIndex: true,
+    useUnifiedTopology: true
     reconnectTries: Number.MAX_VALUE, // Never stop trying to reconnect
     reconnectInterval: 500, // Reconnect every 500ms
     poolSize: 10, // Maintain up to 10 socket connections

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "mongoose": "^5.5.15",
+    "mongoose": "^5.7.4",
     "muri": "^1.3.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const muri = require('muri');
 const defaultMongoOptions = {
   useNewUrlParser: true,
   useCreateIndex: true,
+  useUnifiedTopology: true,
   reconnectTries: Number.MAX_VALUE, // Never stop trying to reconnect
   reconnectInterval: 500, // Reconnect every 500ms
   poolSize: 10, // Maintain up to 10 socket connections


### PR DESCRIPTION
When using the module we are getting a DeprecationWarning that current Server Discovery and Monitoring engine is deprecated and will be removed in a future version. To disable the warning, we need to pass the option { useUnifiedTopology: true } on the constructor, howver, since the module uses Connection.openUri we need to update mongoose to a newer version as per the link on mongoose github.
- https://github.com/Automattic/mongoose/issues/8146