### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,24 @@
 
 [![npm](https://img.shields.io/npm/v/@south-paw/koa-mongoose.svg)](https://www.npmjs.com/package/@south-paw/koa-mongoose)
 [![CI Status](https://img.shields.io/travis/South-Paw/koa-mongoose.svg)](https://travis-ci.org/South-Paw/koa-mongoose)
+[![Coveralls Status](https://img.shields.io/coveralls/github/South-Paw/koa-mongoose.svg)](https://coveralls.io/github/South-Paw/koa-mongoose)
 [![Dependencies](https://david-dm.org/South-Paw/koa-mongoose/status.svg)](https://david-dm.org/South-Paw/koa-mongoose)
 [![Dev Dependencies](https://david-dm.org/South-Paw/koa-mongoose/dev-status.svg)](https://david-dm.org/South-Paw/koa-mongoose?type=dev)
 
 ---
+
+## Features
+
+- Adds `model()` and `document()` to the koa `ctx`
+- Config for automatically loading schemas and events on the mongoose instance
 
 ## Basic Usage
 
 The middleware config accepts a `user` and `pass` or you can use a `uri` or `url` as an escape hatch for other url schemes.
 
 Unauthenticated connections will also work by omitting the `user` and `pass` and only providing a `host`, `port` and `db`.
+
+Note: If you're using the `mongodb+srv` syntax to connect to [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), you [should use the mongoose `dbName` option to specify the database](https://stackoverflow.com/questions/48917591/fail-to-connect-mongoose-to-atlas/48917626#48917626) because you currently cannot in the connection string. ([source](https://mongoosejs.com/docs/connections.html)) Be sure to change the default koa-mongoose `db` option to match as well.
 
 ```js
 const Koa = require('koa');
@@ -33,7 +41,7 @@ const config = {
     useNewUrlParser: true,
     useCreateIndex: true,
     useUnifiedTopology: true,
-    reconnectTries: Number.MAX_VALUE, // Never stop trying to reconnect
+    reconnectTries: Number.MAX_SAFE_INTEGER, // Never stop trying to reconnect
     reconnectInterval: 500, // Reconnect every 500ms
     poolSize: 10, // Maintain up to 10 socket connections
     bufferMaxEntries: 0, // If not connected, return errors immediately rather than waiting for reconnect
@@ -67,19 +75,19 @@ const config = {
     disconnecting: () => console.log('mongoose: disconnecting'),
     disconnected: () => console.log('mongoose: disconnected'),
   },
+  useDefaultErrorHandler: false, // enable or disable the default error handler
 };
 
 // apply the middleware
 app.use(mongoose(config));
 
 // and you can now use the middleware via the ctx with
-// ctx.model(modelName)
-// ctx.document(modelName, document)
+// `ctx.model(modelName)` and `ctx.document(modelName, document)`
 ```
 
 ## Issues and Bugs
 
-If you find any, please report them [here](https://github.com/South-Paw/koa-mongoose/issues) so they can be squashed.
+If you manage to find any, please report them [here](https://github.com/South-Paw/koa-mongoose/issues) so they can be squashed.
 
 ## Development and Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@south-paw/koa-mongoose",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Mongoose middleware for Koa 2",
   "keywords": [
     "koa",
@@ -33,8 +33,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "mongoose": "^5.7.5",
-    "muri": "^1.3.0"
+    "mongoose": "^5.7.5"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/src/__mocks__/mongoose.js
+++ b/src/__mocks__/mongoose.js
@@ -1,8 +1,8 @@
 const mongoose = {};
 
-function __setupCreateConnectionMock(createConnection) {
+const __setupCreateConnectionMock = createConnection => {
   mongoose.createConnection = createConnection;
-}
+};
 
 mongoose.__setupCreateConnectionMock = __setupCreateConnectionMock;
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,7 +8,7 @@ const defaultOpts = {
   useNewUrlParser: true,
   useCreateIndex: true,
   useUnifiedTopology: true,
-  reconnectTries: Number.MAX_VALUE,
+  reconnectTries: Number.MAX_SAFE_INTEGER,
   reconnectInterval: 500,
   poolSize: 10,
   bufferMaxEntries: 0,
@@ -62,7 +62,7 @@ describe(name, () => {
   it(`should call connect with a given uri`, () => {
     const { openUriMock } = mongooseSetup();
 
-    const uri = 'mongodb://localhost/mydb';
+    const uri = 'mongodb+srv://localhost/mydb';
     const opts = { ...defaultOpts };
 
     middleware({ uri });
@@ -134,7 +134,7 @@ describe(name, () => {
 
     middleware({ events: { error, connected }, useDefaultErrorHandler: false });
 
-    expect(onMock).toHaveBeenCalledTimes(3);
+    expect(onMock).toHaveBeenCalledTimes(2);
     expect(onMock).toHaveBeenCalledWith('error', error);
     expect(onMock).toHaveBeenCalledWith('connected', connected);
   });
@@ -192,7 +192,7 @@ describe(name, () => {
     ctx.model('users');
 
     expect(throwMock).toHaveBeenCalledTimes(1);
-    expect(throwMock).toHaveBeenCalledWith(500, new Error(`Model 'users' not found in 'default'`));
+    expect(throwMock).toHaveBeenCalledWith(500, new Error(`Model name 'users' not found in 'default'`));
   });
 
   it(`calling ctx.document should return a provided model document`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,11 +2648,6 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-muri@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/muri/-/muri-1.3.0.tgz#aeccf3db64c56aa7c5b34e00f95b7878527a4721"
-  integrity sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg==
-
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"


### PR DESCRIPTION
## Description

* Removed `muri` from dependencies (enables support for `mongo+srv` urls see #1)
* `debug` name changed from `koa:mongo` to `southpaw:koamongoose`
* Default `reconnectTries` was changed from `Number.MAX_VALUE` changed to `Number.MAX_SAFE_INTEGER`
* Added note about using `mongo+srv` urls to readme